### PR TITLE
get /person?address return 404 instead of 500 if user not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 1. Install node v8.9.4+, npm 5.6.0+, Yarn 1.3.2+
 2. Install and launch mongodb service
-3. Update these config files:
+3. Install and launch rabbitmq service
+4. Update these config files:
 
  - config/default.json
  - config/production.json

--- a/lib/routes/lib/securityRoutes.js
+++ b/lib/routes/lib/securityRoutes.js
@@ -32,7 +32,7 @@ router.get('/me/full', authenticate(), asyncHandler(async (req, res) => {
 
 router.get('/person', asyncHandler(async (req, res) => {
   const person = await securityService.selectPerson(req.query.address)
-  res.send(person)
+  person ? res.send(person) : res.sendStatus(404)
 }))
 
 router.post('/persons/query', asyncHandler(async (req, res) => {

--- a/lib/services/lib/SecurityService.js
+++ b/lib/services/lib/SecurityService.js
@@ -46,7 +46,7 @@ class SecurityService {
       })
       .populate('user')
       .exec()
-    return PersonModel.fromMongo(signature.user, { address: signature.value })
+    return signature ? PersonModel.fromMongo(signature.user, { address: signature.value }) : null
   }
 
   async selectPersons (addresses) {


### PR DESCRIPTION
on client side we need to determine if user exists with this address or not to handle user account creation

in order to this we can use get /person?address route

but now it returns 500 if request address has no linked user

500 status code generaly means that some error on server occurs

it would be more semantic to return 404 if user not exists instead of 500